### PR TITLE
为boot.json 中的依赖描述增加 downloadDir 选项 & 完成zip读取会按照依赖进行加载排序

### DIFF
--- a/src/BeforeSC2/DependenceChecker.ts
+++ b/src/BeforeSC2/DependenceChecker.ts
@@ -37,7 +37,7 @@ export class DependenceChecker {
         // Step 1: Prepare initial indegrees
         const inDegree: Map<ModOrderItem, number> = new Map();
         items.forEach(item => {
-            let dependenciesCount = (item.mod.bootJson.dependenceInfo || []).filter((dep: any) => dep.resolved === true).length;
+            let dependenciesCount = (item.mod.bootJson.dependenceInfo || []).filter((dep: any) => dep.resolved === false).length;
             inDegree.set(item, dependenciesCount);
         });
 
@@ -54,6 +54,7 @@ export class DependenceChecker {
             let current = zeroIndegree.shift() as ModOrderItem;
 
             // Add node to the sorted list
+
             result.pushBackFast(current);
             this.log.log(`DependenceChecker.sortByDependency: Sort ${current.mod.name}`);
 

--- a/src/BeforeSC2/ModLoader.ts
+++ b/src/BeforeSC2/ModLoader.ts
@@ -350,7 +350,7 @@ export class ModLoader {
             }
         }
 
-        this.gSC2DataManager
+        this.modReadCache = this.gSC2DataManager.getDependenceChecker().sortByDependency(this.modReadCache);
         await this.initModInjectEarlyLoadInDomScript();
         await this.gSC2DataManager.getAddonPluginManager().triggerHook('afterInjectEarlyLoad');
         await this.triggerAfterModLoad();

--- a/src/BeforeSC2/ModLoader.ts
+++ b/src/BeforeSC2/ModLoader.ts
@@ -103,6 +103,8 @@ export function checkModBootJsonAddonPlugin(v: any): v is ModBootJsonAddonPlugin
 export interface DependenceInfo {
     modName: string;
     version: string;
+    downloadDir: string;
+    resolved: boolean; //这是一个运行时变量，在完成checkDependence之后被置为 false，之后在 sortDependency 时被置为 true(拓扑排序)
 }
 
 export function checkDependenceInfo(v: any): v is DependenceInfo {
@@ -180,8 +182,11 @@ export class ModLoader {
         this.logger = this.gSC2DataManager.getModUtils().getLogger();
     }
 
+    //待加载的Mod列表
     private modReadCache: ModOrderContainer = new ModOrderContainer();
+    //已加载的Mod列表
     private modCache: ModOrderContainer = new ModOrderContainer();
+    //注册延迟加载的Mod列表
     private modLazyCache: ModOrderContainer = new ModOrderContainer();
 
     // it recorded the do_initModInjectEarlyLoadInDomScript call
@@ -344,6 +349,8 @@ export class ModLoader {
                     this.logger.error(`ModLoader loadTranslateData() unknown loadType: [${loadType}]`);
             }
         }
+
+        this.gSC2DataManager
         await this.initModInjectEarlyLoadInDomScript();
         await this.gSC2DataManager.getAddonPluginManager().triggerHook('afterInjectEarlyLoad');
         await this.triggerAfterModLoad();

--- a/src/BeforeSC2/ModOrderContainer.ts
+++ b/src/BeforeSC2/ModOrderContainer.ts
@@ -391,6 +391,15 @@ export class ModOrderContainer {
      * @param obj
      */
     pushBackFast(obj: ModOrderItem): boolean {
+        if (!this.container.has(obj.name)) {
+            this.container.set(obj.name, new Map<ModLoadFromSourceType, ModOrderItem>());
+        }
+        const m = this.container.get(obj.name)!;
+        m.set(obj.from, obj);
+        const ii = this.order.findIndex(T => T.name === obj.name && T.from === obj.from);
+        if (ii >= 0) {
+            this.order.splice(ii, 1);
+        }
         this.order.push(obj);
         this.checkData();
         return true;

--- a/src/BeforeSC2/ModOrderContainer.ts
+++ b/src/BeforeSC2/ModOrderContainer.ts
@@ -387,6 +387,17 @@ export class ModOrderContainer {
     }
 
     /**
+     * 插入一个元素，这相对于上面的版本忽略了ModOrderItem的构建，并 Assert 不存在同名元素。
+     * @param obj
+     */
+    pushBackFast(obj: ModOrderItem): boolean {
+        this.order.push(obj);
+        this.checkData();
+        return true;
+    }
+
+
+    /**
      * O(2n)
      */
     insertReplace(zip: ModZipReader, from: ModLoadFromSourceType): boolean {


### PR DESCRIPTION
在配置 downloadDir 之后，如果检查到那一个依赖没有被满足（不考虑semver），那么会从 downloadDir 所记录的地址进行下载，重新进行依赖排序和检查。